### PR TITLE
Use $crate in macro calls and allow empty structs

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -12,13 +12,13 @@ pub trait ConfigType {
 
 macro_rules! basic_impl {
     ($ty:ty) => {
-        impl ConfigType for $ty {
+        impl $crate::ConfigType for $ty {
             fn set(&mut self, _path: Path, value: String) -> Result<(), failure::Error> {
                 *self = ron::de::from_str(&value)?;
                 Ok(())
             }
         }
-    }
+    };
 }
 basic_impl!(i8);
 basic_impl!(i16);
@@ -41,6 +41,7 @@ impl ConfigType for String {
         Ok(())
     }
 }
+
 impl<X: DeserializeOwned, Y: DeserializeOwned> ConfigType for (X, Y) {
     fn set(&mut self, _path: Path, value: String) -> Result<(), failure::Error> {
         *self = ron::de::from_str(&value)?;
@@ -55,7 +56,7 @@ pub struct Path {
 impl Path {
     pub fn new(nodes: Vec<String>) -> Path {
         Path {
-            nodes: nodes.into_iter().rev().collect()
+            nodes: nodes.into_iter().rev().collect(),
         }
     }
     pub fn pop_front(&mut self) -> Option<String> {
@@ -69,7 +70,6 @@ impl Path {
     }
 }
 
-
 // Note: makes everything pub
 #[macro_export]
 macro_rules! is_string {
@@ -82,7 +82,6 @@ macro_rules! is_f32 {
     { $y:ty } => {false};
 }
 
-
 #[macro_export]
 macro_rules! get_paths_recurse {
     { $x:ident : $y:ty, $paths:ident } => {
@@ -94,25 +93,24 @@ macro_rules! get_paths_recurse {
     };
 }
 
-
 // NOTE: ignore the $(#[$($m:meta)*])* and corresponding $(#[$($m)*])* when reading. These are just
 // to pass meta items to ALL struct definitions.
 #[macro_export]
 macro_rules! config {
     { $(#[$($m:meta)*])* struct $name:ident { $($t:tt)* } } => {
-        config!{ @define $(#[$($m)*])* $($t)* }
-        config!{ @make_struct $(#[$($m)*])* $name { $($t)* } }
+        $crate::config!{ @define $(#[$($m)*])* $($t)* }
+        $crate::config!{ @make_struct $(#[$($m)*])* $name { $($t)* } }
     };
-    
+
     // Make struct. Ignore substructures. These are already processesd somewhere else.
-    { @make_struct $(#[$($m:meta)*])* $name:ident { $($x:ident : $y:ty $({ $($t:tt)* })* $(,)* )+ } } => {
+    { @make_struct $(#[$($m:meta)*])* $name:ident { $($x:ident : $y:ty $({ $($t:tt)* })* $(,)* )* } } => {
         $(#[$($m)*])*
         pub struct $name {
-            $(pub $x: $y),+
+            $(pub $x: $y),*
         }
-        impl config::ConfigType for $name {
+        impl $crate::ConfigType for $name {
             fn is_leaf() -> bool {false}
-            fn set(&mut self, mut path: config::Path, value: String) -> Result<(), failure::Error> {
+            fn set(&mut self, mut path: $crate::Path, value: String) -> Result<(), failure::Error> {
                 use failure::bail;
                 // TODO/NOTE: path could also easily be &mut if that performs better
 
@@ -129,7 +127,7 @@ macro_rules! config {
                 }
                 Ok(())
             }
-            fn get_paths() -> Vec<config::Path> {
+            fn get_paths() -> Vec<$crate::Path> {
                 let mut paths = Vec::new();
                 $( {
                     get_paths_recurse!($x: $y, paths);
@@ -141,17 +139,17 @@ macro_rules! config {
 
     // accept a sub-structure (and rest)
     { @define $(#[$($m:meta)*])* $x:ident: $y:ident { $($t:tt)* }, $($rest:tt)* } => {
-        config!{$(#[$($m)*])* struct $y { $($t)* } }
-        config!{@define $(#[$($m)*])* $($rest)*}
+        $crate::config!{$(#[$($m)*])* struct $y { $($t)* } }
+        $crate::config!{@define $(#[$($m)*])* $($rest)*}
     };
-    
+
     // The above rule, but just to accept ','
     { @define $(#[$($m:meta)*])* $x:ident: $y:ident { $($t:tt)* } $($rest:tt)* } => {
-        config!{@define $(#[$($m)*])* $x: $y { $($t)* }, $($rest)* }
+        $crate::config!{@define $(#[$($m)*])* $x: $y { $($t)* }, $($rest)* }
     };
     // fields
     { @define $(#[$($m:meta)*])* $x:ident: $y:ty, $($rest:tt)* } => {
-        config!{@define $(#[$($m)*])* $($rest)*}
+        $crate::config!{@define $(#[$($m)*])* $($rest)*}
     };
     { @define $(#[$($m:meta)*])* $x:ident: $y:ty } => {
     };
@@ -159,3 +157,14 @@ macro_rules! config {
     };
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_config() {
+        config![
+            struct Empty {}
+        ];
+    }
+}


### PR DESCRIPTION
`$crate` allows locally defined macros to be used in other crates without explicitly `use`-ing stuff from said crate.

Also allow the creation of empty structs, because why not?